### PR TITLE
Use pose sampling for optimized skeletons

### DIFF
--- a/Runtime/Components/AnimationState.cs
+++ b/Runtime/Components/AnimationState.cs
@@ -55,6 +55,21 @@ namespace DOTSAnimation
             }
         }
 
+        public void SamplePose(ref BufferPoseBlender blender, float timeShift, in DynamicBuffer<ClipSampler> samplers, float blend = 1f)
+        {
+            switch (Type)
+            {
+                case AnimationSamplerType.Single:
+                    SamplePose_SingleClip(ref blender, timeShift, samplers, blend);
+                    break;
+                case AnimationSamplerType.LinearBlend:
+                    SamplePose_LinearBlend(ref blender, timeShift, samplers, blend);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
         public float GetStateTime(in DynamicBuffer<ClipSampler> samplers)
         {
             switch (Type)

--- a/Runtime/Components/AnimationState_LinearBlend.cs
+++ b/Runtime/Components/AnimationState_LinearBlend.cs
@@ -15,7 +15,12 @@ namespace DOTSAnimation
         {
             return LinearBlendSampling.SampleBone(boneIndex, timeShift, samplers, StartSamplerIndex, EndSamplerIndex);
         }
-        
+
+        private readonly void SamplePose_LinearBlend(ref BufferPoseBlender blender, float timeShift, in DynamicBuffer<ClipSampler> samplers, float blend = 1f)
+        {
+            LinearBlendSampling.SamplePose(ref blender, timeShift, samplers, StartSamplerIndex, EndSamplerIndex, blend);
+        }
+
         private readonly float NormalizedTime_LinearBlend(in DynamicBuffer<ClipSampler> samplers)
         { 
             LinearBlendSampling.FindSamplers(samplers, StartSamplerIndex, EndSamplerIndex, Blend, out var firstSamplerIndex, out var secondSamplerIndex);

--- a/Runtime/Components/AnimationState_Single.cs
+++ b/Runtime/Components/AnimationState_Single.cs
@@ -21,6 +21,14 @@ namespace DOTSAnimation
             return sampler.Clip.SampleBone(boneIndex, normalizedTime);
         }
 
+        private readonly void SamplePose_SingleClip(ref BufferPoseBlender blender, float timeShift, in DynamicBuffer<ClipSampler> samplers, float blend = 1f)
+        {
+            var sampler = samplers[StartSamplerIndex];
+            var time = sampler.Time + timeShift * sampler.Speed;
+            var normalizedTime = Loop ? sampler.Clip.LoopToClipTime(time) : time;
+            sampler.Clip.SamplePose(ref blender, blend, normalizedTime);
+        }
+
         private readonly float NormalizedTime_Single(in DynamicBuffer<ClipSampler> samplers)
         {
             var s = samplers[StartSamplerIndex];

--- a/Runtime/Utils/LinearBlendSampling.cs
+++ b/Runtime/Utils/LinearBlendSampling.cs
@@ -26,6 +26,21 @@ namespace DOTSAnimation
             return bone;
         }
 
+        public static void SamplePose(
+            ref BufferPoseBlender blender,
+            float timeShift,
+            in DynamicBuffer<ClipSampler> samplers,
+            int startIndex, int endIndex, float blend = 1f)
+        {
+            for (var i = startIndex; i <= endIndex; i++)
+            {
+                var s = samplers[i];
+                var t = s.Time + timeShift * s.Speed;
+                t = s.Clip.LoopToClipTime(t);
+                s.Clip.SamplePose(ref blender, s.Weight * blend, t);
+            }
+        }
+
         public static void FindSamplers(
             in DynamicBuffer<ClipSampler> samplers,
             int startIndex, int endIndex,

--- a/Runtime/Utils/SingleClipSampling.cs
+++ b/Runtime/Utils/SingleClipSampling.cs
@@ -24,5 +24,15 @@ namespace DOTSAnimation
             current.scale = math.lerp(current.scale, next.scale, blend);
             return current;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SamplePoseBlended(
+            ref BufferPoseBlender blender, float blend, float timeShift,
+            in AnimationState currentState, in AnimationState nextState,
+            in DynamicBuffer<ClipSampler> samplers)
+        {
+            currentState.SamplePose(ref blender, timeShift, samplers, 1f - blend);
+            nextState.SamplePose(ref blender, timeShift, samplers, blend);
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "unity": "2020.3",
   "description": "DOTSAnimation is a high level Animation State Machine framework for DOTS",
   "dependencies": {
-    "com.latios.latiosframework": "0.5.1"
+    "com.latios.latiosframework": "0.5.2"
   },
   "unityRelease": "30f1",
   "keywords": [


### PR DESCRIPTION
Pose sampling allows decompression to reuse cached metadata for all bone transforms which regularly performs 4 - 10 times faster. The changes in this PR make optimized skeletons use pose sampling using a new `BufferPoseBlender` utility. This utility also takes care of handling the hierarchy including `ParentScaleInverse`.

This change requires updating Latios Framework to 0.5.2.