### PR TITLE
Move clips into visual editor too

### DIFF
--- a/Editor/CustomEditors/AnimationClipAssetEditor.cs
+++ b/Editor/CustomEditors/AnimationClipAssetEditor.cs
@@ -32,26 +32,32 @@ namespace DMotion.Editor
 
         public override void OnInspectorGUI()
         {
-            using (new EditorGUILayout.HorizontalScope())
+            EditorGUILayout.HelpBox("You should use the Visual Editor to edit this asset.", MessageType.Warning);
+            using (new EditorGUI.DisabledScope(true))
             {
-                EditorGUILayout.LabelField("Preview Object");
-                preview.GameObject = (GameObject)EditorGUILayout.ObjectField(preview.GameObject, typeof(GameObject), true);
-            }
-            using (var c = new EditorGUI.ChangeCheckScope())
-            {
-                EditorGUILayout.PropertyField(clipProperty, true);
-                preview.Clip = ClipTarget.Clip;
-
-                if (c.changed)
+                using (new EditorGUILayout.HorizontalScope())
                 {
-                    serializedObject.ApplyModifiedProperties();
-                    serializedObject.Update();
+                    EditorGUILayout.LabelField("Preview Object");
+                    preview.GameObject =
+                        (GameObject)EditorGUILayout.ObjectField(preview.GameObject, typeof(GameObject), true);
                 }
-                
-                var drawerRect = EditorGUILayout.GetControlRect();
-                //TODO: This magic number is a right padding. Not why this is needed or of a better alternative
-                drawerRect.xMax -= 60;
-                eventsPropertyDrawer.OnInspectorGUI(drawerRect);
+
+                using (var c = new EditorGUI.ChangeCheckScope())
+                {
+                    EditorGUILayout.PropertyField(clipProperty, true);
+                    preview.Clip = ClipTarget.Clip;
+
+                    if (c.changed)
+                    {
+                        serializedObject.ApplyModifiedProperties();
+                        serializedObject.Update();
+                    }
+
+                    var drawerRect = EditorGUILayout.GetControlRect();
+                    //TODO: This magic number is a right padding. Not why this is needed or of a better alternative
+                    drawerRect.xMax -= 60;
+                    eventsPropertyDrawer.OnInspectorGUI(drawerRect);
+                }
             }
         }
 

--- a/Editor/EditorPreview/PlayableGraphPreview.cs
+++ b/Editor/EditorPreview/PlayableGraphPreview.cs
@@ -25,11 +25,22 @@ namespace DMotion.Editor
         protected abstract PlayableGraph BuildGraph();
         protected abstract IEnumerable<AnimationClip> Clips { get; }
         protected abstract float SampleTime { get; }
+        
+        protected abstract float PercentageDone { get; }
+        
+        protected abstract int FrameCount { get; }
+        
+        protected abstract string PreviewName { get; }
+
+        private GUIStyle TextStyle;
 
         public void Initialize()
         {
             AnimationMode.StartAnimationMode();
             RefreshPreviewObjects();
+            
+            TextStyle = new GUIStyle(EditorStyles.boldLabel);
+            TextStyle.alignment = TextAnchor.LowerCenter;
         }
         private void SetGameObjectPreview(GameObject newValue)
         {
@@ -195,6 +206,9 @@ namespace DMotion.Editor
 
                     var resultRender = previewRenderUtility.EndPreview();
                     GUI.DrawTexture(r, resultRender, ScaleMode.StretchToFill, false);
+
+                    var newRect = new Rect(r);
+                    GUI.Label(newRect, $"{PreviewName}\n{SampleTime:F2} ({PercentageDone:F2}%) Frame {FrameCount}", TextStyle);
                 }
             }
         }

--- a/Editor/EditorPreview/SingleClipPreview.cs
+++ b/Editor/EditorPreview/SingleClipPreview.cs
@@ -37,6 +37,12 @@ namespace DMotion.Editor
             set => sampleNormalizedTime = Mathf.Clamp01(value);
         }
         protected override float SampleTime => SampleNormalizedTime * Clip.length;
+
+        protected override float PercentageDone => SampleTime * 100f / Clip.length;
+        
+        protected override int FrameCount => Mathf.RoundToInt(Clip.frameRate * SampleTime);
+
+        protected override string PreviewName => Clip.name;
         
         public SingleClipPreview(AnimationClip clip)
         {

--- a/Editor/EditorWindows/AnimationStateInspector.cs
+++ b/Editor/EditorWindows/AnimationStateInspector.cs
@@ -7,6 +7,8 @@ namespace DMotion.Editor
     internal class SingleStateInspector : AnimationStateInspector
     {
         private SerializedProperty clipProperty;
+        private AnimationEventsPropertyDrawer _eventsPropertyDrawer;
+        
         protected override void OnEnable()
         {
             base.OnEnable();
@@ -15,7 +17,75 @@ namespace DMotion.Editor
 
         protected override void DrawChildProperties()
         {
-            EditorGUILayout.PropertyField(clipProperty);
+            if (clipProperty.objectReferenceValue == null)
+            {
+                using (var c = new EditorGUI.ChangeCheckScope())
+                {
+                    var clipRef = (AnimationClip) EditorGUILayout.ObjectField(null, typeof(AnimationClip), false);
+
+                    if (c.changed && clipRef != null)
+                    {
+                        clipProperty.objectReferenceValue = model.StateView.StateMachine.CreateClipAsset(clipRef);
+                        serializedObject.ApplyModifiedProperties();
+                    }
+                }
+                return;
+            }
+
+            var childValue = (AnimationClipAsset) clipProperty.objectReferenceValue;
+            var nestedSerializedObject = new SerializedObject(childValue);
+            using (var c = new EditorGUI.ChangeCheckScope())
+            {
+                GUILayout.BeginHorizontal();
+                {
+                    var controlRect = EditorGUILayout.GetControlRect();
+                    var copyRect = new Rect(controlRect);
+                    copyRect.width -= (controlRect.height + EditorGUIUtility.standardVerticalSpacing);
+
+                    childValue.Clip =
+                        (AnimationClip)EditorGUI.ObjectField(copyRect, childValue.Clip, typeof(AnimationClip), true);
+
+                    controlRect.width = controlRect.height;
+                    controlRect.x += copyRect.width + EditorGUIUtility.standardVerticalSpacing;
+                    if (GUI.Button(controlRect, PlayClipContent, PlayClipStyle))
+                    {
+                        Debug.Log("Pressing play");
+                        if (model.Preview != null && model.Preview is SingleClipPreview singleClipPreview)
+                        {
+                            if (model.Preview.GameObject != model.StateView.StateMachine.ClipPreviewGameObject)
+                                model.Preview.GameObject = model.StateView.StateMachine.ClipPreviewGameObject;
+                            singleClipPreview.Clip = childValue.Clip;
+                            if (_eventsPropertyDrawer != null)
+                            {
+                                // Detatch the previous preview from the single preview pane so we can use the new
+                                // one.
+                                if (model.StateView.ParentView._lastUsedDrawer != null)
+                                    model.StateView.ParentView._lastUsedDrawer.SetPreview(null);
+                                _eventsPropertyDrawer.SetPreview(singleClipPreview);
+                                model.StateView.ParentView._lastUsedDrawer = _eventsPropertyDrawer;
+                            }
+                        }
+                    }
+                }
+                GUILayout.EndHorizontal();
+                // TODO add a play button or something on this to let it change hte preview
+
+                var drawerRect = EditorGUILayout.GetControlRect();
+                drawerRect.xMax -= 60;
+                
+                if (_eventsPropertyDrawer == null)
+                    _eventsPropertyDrawer = new AnimationEventsPropertyDrawer(
+                    childValue, 
+                    nestedSerializedObject.FindProperty(nameof(AnimationClipAsset.Events)),
+                    null);
+                _eventsPropertyDrawer.OnInspectorGUI(drawerRect);
+
+                if (c.changed)
+                {
+                    nestedSerializedObject.ApplyModifiedProperties();
+                    serializedObject.ApplyModifiedProperties();
+                }
+            }
         }
     }
     
@@ -46,6 +116,8 @@ namespace DMotion.Editor
     {
         internal StateNodeView StateView;
         internal AnimationStateAsset StateAsset => StateView.State;
+
+        internal PlayableGraphPreview Preview;
     }
 
     internal abstract class AnimationStateInspector : StateMachineInspector<AnimationStateInspectorModel>
@@ -54,6 +126,39 @@ namespace DMotion.Editor
         private SerializedProperty speedProperty;
         private SerializedProperty outTransitionsProperty;
 
+        private static GUIStyle addRemoveEventStyle;
+        private static GUIContent addEventContent;
+
+        protected static GUIStyle PlayClipStyle
+        {
+            get
+            {
+                if (addRemoveEventStyle == null)
+                {
+                    addRemoveEventStyle = new GUIStyle(EditorStyles.miniButton)
+                    {
+                        fixedHeight = 0,
+                        padding = new RectOffset(-1, 1, 0, 0)
+                    };
+                }
+
+                return addRemoveEventStyle;
+            }
+        }
+
+        protected static GUIContent PlayClipContent
+        {
+            get
+            {
+                if (addEventContent == null)
+                {
+                    addEventContent = EditorGUIUtility.IconContent("Animation.Play", "Play Clip");
+                }
+
+                return addEventContent;
+            }
+        }
+        
         protected virtual void OnEnable()
         {
             loopProperty = serializedObject.FindProperty(nameof(SingleClipStateAsset.Loop));

--- a/Editor/EditorWindows/AnimationStateInspector.cs
+++ b/Editor/EditorWindows/AnimationStateInspector.cs
@@ -59,10 +59,12 @@ namespace DMotion.Editor
                             {
                                 // Detatch the previous preview from the single preview pane so we can use the new
                                 // one.
-                                if (model.StateView.ParentView._lastUsedDrawer != null)
-                                    model.StateView.ParentView._lastUsedDrawer.SetPreview(null);
+                                if (model.StateView.ParentView.lastUsedDrawer != null)
+                                    model.StateView.ParentView.lastUsedDrawer.SetPreview(null);
                                 _eventsPropertyDrawer.SetPreview(singleClipPreview);
-                                model.StateView.ParentView._lastUsedDrawer = _eventsPropertyDrawer;
+                                model.StateView.ParentView.lastUsedDrawer = _eventsPropertyDrawer;
+                                model.Preview.Initialize();
+                                model.StateView.ParentView.ShouldDrawSingleClipPreview = true;
                             }
                         }
                     }

--- a/Editor/EditorWindows/AnimationStateMachineEditorView.cs
+++ b/Editor/EditorWindows/AnimationStateMachineEditorView.cs
@@ -47,6 +47,9 @@ namespace DMotion.Editor
         internal StateMachineAsset StateMachine => model.StateMachineAsset;
         internal VisualTreeAsset StateNodeXml => model.StateNodeXml;
 
+        public SingleClipPreview SingleClipPreview;
+        internal AnimationEventsPropertyDrawer _lastUsedDrawer;
+
         public AnimationStateMachineEditorView()
         {
             var gridBg = new GridBackground();
@@ -56,6 +59,11 @@ namespace DMotion.Editor
             this.AddManipulator(new ContentDragger());
             this.AddManipulator(new SelectionDragger());
             this.AddManipulator(new RectangleSelector());
+
+            SingleClipPreview = new SingleClipPreview(null);
+            if (model.StateMachineAsset != null)
+                SingleClipPreview.GameObject = model.StateMachineAsset.ClipPreviewGameObject;
+            SingleClipPreview.Initialize();
         }
 
         public override void BuildContextualMenu(ContextualMenuPopulateEvent evt)
@@ -207,11 +215,12 @@ namespace DMotion.Editor
         {
             var inspectorModel = new AnimationStateInspectorModel
             {
-                StateView = obj
+                StateView = obj,
             };
             switch (obj)
             {
                 case SingleClipStateNodeView _:
+                    inspectorModel.Preview = SingleClipPreview;
                     model.InspectorView.SetInspector<SingleStateInspector, AnimationStateInspectorModel>
                         (inspectorModel.StateAsset, inspectorModel);
                     break;

--- a/Editor/EditorWindows/AnimationStateMachineEditorView.cs
+++ b/Editor/EditorWindows/AnimationStateMachineEditorView.cs
@@ -253,6 +253,9 @@ namespace DMotion.Editor
                         (inspectorModel.StateAsset, inspectorModel);
                     break;
                 case LinearBlendStateNodeView _:
+                    // In the future we could theoretically send along a preview of the whole state at once rather than
+                    // individual ones.
+                    inspectorModel.Preview = SingleClipPreview;
                     model.InspectorView.SetInspector<LinearBlendStateInspector, AnimationStateInspectorModel>
                         (inspectorModel.StateAsset, inspectorModel);
                     break;

--- a/Editor/EditorWindows/AnimationStateMachineEditorWindow.cs
+++ b/Editor/EditorWindows/AnimationStateMachineEditorWindow.cs
@@ -36,7 +36,7 @@ namespace DMotion.Editor
         internal static void ShowExample()
         {
             var wnd = GetWindow<AnimationStateMachineEditorWindow>();
-            wnd.titleContent = new GUIContent("State Machine Editor");
+            wnd.titleContent = new GUIContent($"State Machine Editor");
             wnd.OnSelectionChange();
         }
 
@@ -51,7 +51,16 @@ namespace DMotion.Editor
                 parametersInspectorView = root.Q<StateMachineInspectorView>("parameters-inspector");
             }
         }
-        
+
+        private void OnDestroy()
+        {
+            if (stateMachineEditorView != null)
+            {
+                if (stateMachineEditorView.SingleClipPreview != null)
+                    stateMachineEditorView.SingleClipPreview.Dispose();
+            }
+        }
+
         [OnOpenAsset]
         internal static bool OnOpenBehaviourTree(int instanceId, int line)
         {

--- a/Editor/EditorWindows/AnimationStateMachineEditorWindow.cs
+++ b/Editor/EditorWindows/AnimationStateMachineEditorWindow.cs
@@ -49,6 +49,16 @@ namespace DMotion.Editor
                 stateMachineEditorView = root.Q<AnimationStateMachineEditorView>();
                 inspectorView = root.Q<StateMachineInspectorView>("inspector");
                 parametersInspectorView = root.Q<StateMachineInspectorView>("parameters-inspector");
+
+                var previewElement = new VisualElement();
+                previewElement.Add(new IMGUIContainer(PreviewOnInspectorGUI));
+                previewElement.style.position = new StyleEnum<Position>(Position.Absolute);
+                previewElement.style.bottom = new StyleLength(new Length(EditorGUIUtility.standardVerticalSpacing, LengthUnit.Pixel));
+                previewElement.style.right =
+                    new StyleLength(new Length(EditorGUIUtility.standardVerticalSpacing, LengthUnit.Pixel));
+                previewElement.style.width = new StyleLength(new Length(300, LengthUnit.Pixel));
+                previewElement.style.height = new StyleLength(new Length(300, LengthUnit.Pixel));
+                root.Add(previewElement);
             }
         }
 
@@ -58,6 +68,16 @@ namespace DMotion.Editor
             {
                 if (stateMachineEditorView.SingleClipPreview != null)
                     stateMachineEditorView.SingleClipPreview.Dispose();
+            }
+        }
+
+        public void PreviewOnInspectorGUI()
+        {
+            if (stateMachineEditorView.ShouldDrawSingleClipPreview && stateMachineEditorView.SingleClipPreview != null)
+            {
+                var controlRect = EditorGUILayout.GetControlRect();
+                controlRect.height = controlRect.width;
+                stateMachineEditorView.SingleClipPreview.DrawPreview(controlRect, GUIStyle.none);
             }
         }
 

--- a/Editor/EditorWindows/AnimationStateMachineEditorWindow.uxml
+++ b/Editor/EditorWindows/AnimationStateMachineEditorWindow.uxml
@@ -3,7 +3,7 @@
     <DMotion.Editor.SplitView fixed-pane-initial-dimension="300">
         <ui:VisualElement name="left-panel">
             <ui:VisualElement name="left-panel-content">
-                <DMotion.Editor.SplitView orientation="Vertical" fixed-pane-initial-dimension="125">
+                <DMotion.Editor.SplitView orientation="Vertical" fixed-pane-initial-dimension="200">
                     <DMotion.Editor.StateMachineInspectorView name="parameters-inspector" class="inspector-container" />
                     <DMotion.Editor.StateMachineInspectorView name="inspector" class="inspector-container" style="height: 142px;" />
                 </DMotion.Editor.SplitView>

--- a/Editor/EditorWindows/ParametersInspector.cs
+++ b/Editor/EditorWindows/ParametersInspector.cs
@@ -22,6 +22,23 @@ namespace DMotion.Editor
     {
         public override void OnInspectorGUI()
         {
+            EditorGUILayout.LabelField($"Editing:");
+            EditorGUILayout.LabelField($"    {serializedObject.FindProperty("m_Name").stringValue}");
+
+            if (target is StateMachineAsset stateMachineAsset)
+            {
+                EditorGUILayout.LabelField($"Preview Object:");
+                using (var c = new EditorGUI.ChangeCheckScope())
+                {
+                    stateMachineAsset.ClipPreviewGameObject =
+                        (GameObject)EditorGUILayout.ObjectField(stateMachineAsset.ClipPreviewGameObject,
+                            typeof(GameObject), true);
+                    if (c.changed)
+                        serializedObject.ApplyModifiedProperties();
+                }
+            }
+            EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
+
             using (new EditorGUILayout.VerticalScope())
             {
                 using (new EditorGUILayout.HorizontalScope())

--- a/Editor/EditorWindows/StateMachineEditorUtils.cs
+++ b/Editor/EditorWindows/StateMachineEditorUtils.cs
@@ -8,6 +8,27 @@ namespace DMotion.Editor
 {
     internal static class StateMachineEditorUtils
     {
+        public static AnimationClipAsset CreateClipAsset(this StateMachineAsset stateMachineAsset, AnimationClip clipReference)
+        {
+            var clip = ScriptableObject.CreateInstance<AnimationClipAsset>();
+
+            clip.name = $"New Clip Asset {stateMachineAsset.States.Count + 1}";
+            clip.Clip = clipReference;
+            stateMachineAsset.Clips.Add(clip);
+            AssetDatabase.AddObjectToAsset(clip, stateMachineAsset);
+            
+            AssetDatabase.SaveAssets();
+            return clip;
+        }
+
+        public static void DeleteClipAsset(this StateMachineAsset stateMachineAsset, AnimationClipAsset clipAsset)
+        {
+            //Remove all transitions that reference this state
+            stateMachineAsset.Clips.Remove(clipAsset);
+            AssetDatabase.RemoveObjectFromAsset(clipAsset);
+            AssetDatabase.SaveAssets();
+        }
+        
         public static AnimationStateAsset CreateState(this StateMachineAsset stateMachineAsset, Type type)
         {
             Assert.IsTrue(typeof(AnimationStateAsset).IsAssignableFrom(type));

--- a/Editor/EditorWindows/StateMachineEditorUtils.cs
+++ b/Editor/EditorWindows/StateMachineEditorUtils.cs
@@ -14,6 +14,7 @@ namespace DMotion.Editor
 
             clip.name = $"New Clip Asset {stateMachineAsset.States.Count + 1}";
             clip.Clip = clipReference;
+            clip.Events = Array.Empty<Authoring.AnimationClipEvent>();
             stateMachineAsset.Clips.Add(clip);
             AssetDatabase.AddObjectToAsset(clip, stateMachineAsset);
             

--- a/Editor/EditorWindows/StateMachineInspectorView.cs
+++ b/Editor/EditorWindows/StateMachineInspectorView.cs
@@ -44,5 +44,13 @@ namespace DMotion.Editor
             });
             Add(imgui);
         }
+    
+        public void ClearInspector()
+        {
+            if (editor != null)
+                Object.DestroyImmediate(editor);
+
+            Clear();
+        }
     }
 }

--- a/Editor/EditorWindows/StateNodeView.cs
+++ b/Editor/EditorWindows/StateNodeView.cs
@@ -50,6 +50,8 @@ namespace DMotion.Editor
         internal Action<StateNodeView> StateSelectedEvent;
         public AnimationStateAsset State => model.StateAsset;
         public StateMachineAsset StateMachine => model.ParentView.StateMachine;
+
+        public AnimationStateMachineEditorView ParentView => model.ParentView;
         public Port input;
         public Port output;
 

--- a/Editor/PropertyDrawers/AnimationEventsPropertyDrawer.cs
+++ b/Editor/PropertyDrawers/AnimationEventsPropertyDrawer.cs
@@ -24,7 +24,7 @@ namespace DMotion.Editor
         private bool isDraggingTimeMarker = false;
         private int eventMarkerDragIndex = -1;
         
-        private readonly SingleClipPreview preview;
+        private SingleClipPreview preview;
         private readonly SerializedProperty property;
         private readonly AnimationClipAsset clipAsset;
 
@@ -99,9 +99,18 @@ namespace DMotion.Editor
             this.clipAsset = clipAsset;
             this.preview = preview;
             this.property = property;
-            timeMarkerTime = preview.SampleNormalizedTime;
+            if (preview != null)
+                timeMarkerTime = preview.SampleNormalizedTime;
         }
 
+        public void SetPreview(SingleClipPreview p)
+        {
+            this.preview = p;
+            if (p != null)
+                timeMarkerTime = p.SampleNormalizedTime;
+            else
+                timeMarkerTime = 0f;
+        }
 
         public void OnInspectorGUI(Rect area)
         {
@@ -140,7 +149,8 @@ namespace DMotion.Editor
                             if (!Mathf.Approximately(cachedEvent.NormalizedTime, currentEvent.NormalizedTime))
                             {
                                 eventMarkerDragIndex = i;
-                                preview.SampleNormalizedTime = currentEvent.NormalizedTime;
+                                if (preview != null)
+                                    preview.SampleNormalizedTime = currentEvent.NormalizedTime;
                                 break;
                             }
                         }
@@ -253,14 +263,16 @@ namespace DMotion.Editor
             {
                 var time = PixelsToNormalizedTime(currentEvent.mousePosition.x, timeMarker.VisualRect, dragArea);
                 timeMarkerTime = time;
-                preview.SampleNormalizedTime = time;
+                if (preview != null)
+                    preview.SampleNormalizedTime = time;
                 currentEvent.Use();
             }
             else if (eventMarkerDragIndex >= 0)
             {
                 var eventMarker = eventMarkers[eventMarkerDragIndex];
                 var time = PixelsToNormalizedTime(currentEvent.mousePosition.x, eventMarker.VisualRect, dragArea);
-                preview.SampleNormalizedTime = time;
+                if (preview != null)
+                    preview.SampleNormalizedTime = time;
 
                 clipAsset.Events[eventMarkerDragIndex].NormalizedTime = time;
 

--- a/Editor/PropertyDrawers/AnimationEventsPropertyDrawer.cs
+++ b/Editor/PropertyDrawers/AnimationEventsPropertyDrawer.cs
@@ -132,6 +132,8 @@ namespace DMotion.Editor
 
             using (var c = new EditorGUI.ChangeCheckScope())
             {
+                if (clipAsset == null || clipAsset.Events == null)
+                    return;
                 var cachedEvents = clipAsset.Events.ToList();
                 GUI.color = Color.white;
                 EditorGUILayout.PropertyField(property, GUIContent.none, true);
@@ -307,6 +309,8 @@ namespace DMotion.Editor
                 GUI.DrawTexture(timeMarker.VisualRect, WhiteTex);
             }
             {
+                if (clipAsset == null || clipAsset.Events == null)
+                    return;
                 eventMarkers.Clear();
                 for (var i = 0; i < clipAsset.Events.Length; i++)
                 {

--- a/Runtime/Authoring/AnimationStateMachine/StateMachineAsset.cs
+++ b/Runtime/Authoring/AnimationStateMachine/StateMachineAsset.cs
@@ -10,8 +10,9 @@ namespace DMotion.Authoring
         public AnimationStateAsset DefaultState;
         public List<AnimationStateAsset> States = new List<AnimationStateAsset>();
         public List<AnimationParameterAsset> Parameters = new List<AnimationParameterAsset>();
+        public List<AnimationClipAsset> Clips = new List<AnimationClipAsset>();
+        public int ClipCount => Clips.Count;
 
-        public IEnumerable<AnimationClipAsset> Clips => States.SelectMany(s => s.Clips);
-        public int ClipCount => States.Sum(s => s.ClipCount);
+        public GameObject ClipPreviewGameObject;
     }
 }


### PR DESCRIPTION
This PR moves AnimationClipAssets into the visual editor along with the preview window and related event inspectors. This unifies the experience and makes it easier to browse different assets (in my opinion). 

Here's an example of the changes: 
![image](https://user-images.githubusercontent.com/19557336/182038305-43d821bb-5c64-4bf0-985a-135e0b7ddaf6.png)
