### PR TITLE
AnimationParameterAsset Hash Fixes

### DIFF
--- a/Runtime/Authoring/AnimationStateMachine/AnimationParameterAsset.cs
+++ b/Runtime/Authoring/AnimationStateMachine/AnimationParameterAsset.cs
@@ -5,6 +5,6 @@ namespace DMotion.Authoring
 {
     public abstract class AnimationParameterAsset : StateMachineSubAsset
     {
-        public int Hash => name.GetHashCode();
+        public int Hash => ((FixedString64Bytes) name).GetHashCode();
     }
 }

--- a/Runtime/Utils/StateMachineParameterUtils.cs
+++ b/Runtime/Utils/StateMachineParameterUtils.cs
@@ -33,7 +33,7 @@ namespace DMotion
         }
 
 
-        public static void SetParameter(this DynamicBuffer<BoolParameter> parameters, FixedString32Bytes name,
+        public static void SetParameter(this DynamicBuffer<BoolParameter> parameters, FixedString64Bytes name,
             bool value)
         {
             var hash = name.GetHashCode();
@@ -53,7 +53,7 @@ namespace DMotion
             return false;
         }
 
-        public static bool TryGetValue(this DynamicBuffer<BoolParameter> parameters, FixedString32Bytes name,
+        public static bool TryGetValue(this DynamicBuffer<BoolParameter> parameters, FixedString64Bytes name,
             out bool value)
         {
             var hash = name.GetHashCode();
@@ -85,7 +85,7 @@ namespace DMotion
         }
 
 
-        public static void SetParameter(this DynamicBuffer<BlendParameter> parameters, FixedString32Bytes name,
+        public static void SetParameter(this DynamicBuffer<BlendParameter> parameters, FixedString64Bytes name,
             float value)
         {
             var hash = name.GetHashCode();
@@ -116,7 +116,7 @@ namespace DMotion
             return false;
         }
 
-        public static bool TryGetValue(this DynamicBuffer<BlendParameter> parameters, FixedString32Bytes name,
+        public static bool TryGetValue(this DynamicBuffer<BlendParameter> parameters, FixedString64Bytes name,
             out float value)
         {
             var hash = name.GetHashCode();


### PR DESCRIPTION
- Fixed AnimationParameterAsset using incorrect string type name hash
- Updated Get/Set functions in StateMachineParameterUtils.cs to use same FixedString type as parameter Name