### PR TITLE
fix: check for return value of -1 when calling IdToIndex

### DIFF
--- a/Runtime/Utils/LinearBlendStateUtils.cs
+++ b/Runtime/Utils/LinearBlendStateUtils.cs
@@ -75,6 +75,10 @@ namespace DMotion
         {
             Assert.IsTrue(thresholds.IsCreated);
             var startIndex = samplers.IdToIndex(animation.StartSamplerId);
+            
+            if(startIndex == -1)
+                return;
+            
             var endIndex = startIndex + thresholds.Length - 1;
 
             //we assume thresholds are sorted here

--- a/Runtime/Utils/SingleClipStateUtils.cs
+++ b/Runtime/Utils/SingleClipStateUtils.cs
@@ -57,17 +57,21 @@ namespace DMotion
             ref DynamicBuffer<ClipSampler> samplers)
         {
             var samplerIndex = samplers.IdToIndex(animation.StartSamplerId);
-            var sampler = samplers[samplerIndex];
-            sampler.Weight = animation.Weight;
 
-            sampler.PreviousTime = sampler.Time;
-            sampler.Time += dt * animation.Speed;
-            if (animation.Loop)
+            if (samplerIndex >= 0)
             {
-                sampler.LoopToClipTime();
-            }
+                var sampler = samplers[samplerIndex];
+                sampler.Weight = animation.Weight;
 
-            samplers[samplerIndex] = sampler;
+                sampler.PreviousTime = sampler.Time;
+                sampler.Time += dt * animation.Speed;
+                if (animation.Loop)
+                {
+                    sampler.LoopToClipTime();
+                }
+
+                samplers[samplerIndex] = sampler;
+            }
         }
     }
 }


### PR DESCRIPTION
check if IdToIndex doesn't return -1 in SingleClipStateUtils.UpdateSamplers and LinearBlendStateUtils.UpdateSamplers